### PR TITLE
Refactor class config to use reusable loadout helper

### DIFF
--- a/Class.cfg
+++ b/Class.cfg
@@ -17,7 +17,7 @@ set do_bind_class_select "bind KP_5 vstr br_covert; bind KP_DOWNARROW vstr br_so
 //
 // TEAM SAY & SELECTION
 //
-set teamed_true "set spawncycle "vstr set_spawn0"; set spawnreset "vstr set_spawn0"; vstr spawncycle; vstr set_class; vstr say_class; vstr reset_cyclers"
+set teamed_true "set spawncycle "vstr set_spawn0"; set spawnreset "vstr set_spawn0"; vstr spawncycle; vstr apply_loadout; vstr say_class"
 set teamed_false "set spawncycle "vstr spawncycle_s"; set spawnreset "vstr spawncycle_s"; set set_class "vstr set_class_s"; set say_class "vstr say_class_s"; set say_spawn "vstr say_spawn_s"; vstr reset_cyclers"
 
 set set_team_b "echo '^rAllies; set set_class "vstr set_class_b"; set say_class "vstr b_class_say"; vstr teamed_true"
@@ -30,30 +30,32 @@ set set_class_b "vstr play_sound; vstr b_team; vstr b_class_echo"
 set set_class_r "vstr play_sound; vstr r_team; vstr r_class_echo"
 
 set say_class_s "echo You need to ^r'^rchoose team first"
+// Reusable helper for setting class and resetting cyclers
+set apply_loadout "vstr set_class; vstr reset_cyclers"
 
 // ########################################
 // ## SET A (AXIS) TEAM CLASS & LOADOUT ###
 // ########################################
 
-set br_covert1 "vstr b_covert1; vstr r_covert1; vstr set_class; vstr reset_cyclers; set br_covert "vstr br_covert2""
-set br_covert2 "vstr b_covert2; vstr r_covert2; vstr set_class; vstr reset_cyclers; set br_covert "vstr br_covert3""
-set br_covert3 "vstr b_covert3; vstr r_covert3; vstr set_class; vstr reset_cyclers; set br_covert "vstr br_covert1""
+set br_covert1 "vstr b_covert1; vstr r_covert1; vstr apply_loadout; set br_covert "vstr br_covert2""
+set br_covert2 "vstr b_covert2; vstr r_covert2; vstr apply_loadout; set br_covert "vstr br_covert3""
+set br_covert3 "vstr b_covert3; vstr r_covert3; vstr apply_loadout; set br_covert "vstr br_covert1""
 
-set br_soldier1 "vstr b_soldier1; vstr r_soldier1; vstr set_class; vstr reset_cyclers; set br_soldier "vstr br_soldier2""
-set br_soldier2 "vstr b_soldier2; vstr r_soldier2; vstr set_class; vstr reset_cyclers; set br_soldier "vstr br_soldier3""
-set br_soldier3 "vstr b_soldier3; vstr r_soldier3; vstr set_class; vstr reset_cyclers; set br_soldier "vstr br_soldier4""
-set br_soldier4 "vstr b_soldier4; vstr r_soldier4; vstr set_class; vstr reset_cyclers; set br_soldier "vstr br_soldier5""
-set br_soldier5 "vstr b_soldier5; vstr r_soldier5; vstr set_class; vstr reset_cyclers; set br_soldier "vstr br_soldier1""
+set br_soldier1 "vstr b_soldier1; vstr r_soldier1; vstr apply_loadout; set br_soldier "vstr br_soldier2""
+set br_soldier2 "vstr b_soldier2; vstr r_soldier2; vstr apply_loadout; set br_soldier "vstr br_soldier3""
+set br_soldier3 "vstr b_soldier3; vstr r_soldier3; vstr apply_loadout; set br_soldier "vstr br_soldier4""
+set br_soldier4 "vstr b_soldier4; vstr r_soldier4; vstr apply_loadout; set br_soldier "vstr br_soldier5""
+set br_soldier5 "vstr b_soldier5; vstr r_soldier5; vstr apply_loadout; set br_soldier "vstr br_soldier1""
 
-set br_fldops1 "vstr b_fldops1; vstr r_fldops1; vstr set_class; vstr reset_cyclers; set br_fldops "vstr br_fldops2""
-set br_fldops2 "vstr b_fldops2; vstr r_fldops2; vstr set_class; vstr reset_cyclers; set br_fldops "vstr br_fldops1""
+set br_fldops1 "vstr b_fldops1; vstr r_fldops1; vstr apply_loadout; set br_fldops "vstr br_fldops2""
+set br_fldops2 "vstr b_fldops2; vstr r_fldops2; vstr apply_loadout; set br_fldops "vstr br_fldops1""
 
-set br_eng1 "vstr b_eng1; vstr r_eng1; vstr set_class; vstr reset_cyclers; set br_eng "vstr br_eng2""
-set br_eng2 "vstr b_eng2; vstr r_eng2; vstr set_class; vstr reset_cyclers; set br_eng "vstr br_eng3""
-set br_eng3 "vstr b_eng3; vstr r_eng3; vstr set_class; vstr reset_cyclers; set br_eng "vstr br_eng1""
+set br_eng1 "vstr b_eng1; vstr r_eng1; vstr apply_loadout; set br_eng "vstr br_eng2""
+set br_eng2 "vstr b_eng2; vstr r_eng2; vstr apply_loadout; set br_eng "vstr br_eng3""
+set br_eng3 "vstr b_eng3; vstr r_eng3; vstr apply_loadout; set br_eng "vstr br_eng1""
 
-set br_medic1 "vstr b_medic1; vstr r_medic1; vstr set_class; vstr reset_cyclers; set br_medic "vstr br_medic2""
-set br_medic2 "vstr b_medic2; vstr r_medic2; vstr set_class; vstr reset_cyclers; set br_medic "vstr br_medic1""
+set br_medic1 "vstr b_medic1; vstr r_medic1; vstr apply_loadout; set br_medic "vstr br_medic2""
+set br_medic2 "vstr b_medic2; vstr r_medic2; vstr apply_loadout; set br_medic "vstr br_medic1""
 
 set reset_cyclers "set br_covert "vstr br_covert1"; set br_soldier "vstr br_soldier1"; set br_fldops "vstr br_fldops1"; set br_eng "vstr br_eng1"; set br_medic "vstr br_medic1""
 


### PR DESCRIPTION
## Summary
- add `apply_loadout` helper to set class and reset cyclers
- use `apply_loadout` throughout class cycle bindings
- use `apply_loadout` when joining a team

## Testing
- `echo "No tests to run"`


------
https://chatgpt.com/codex/tasks/task_e_68ac93a9f6288324a79aa13fbcca355b